### PR TITLE
💚fix test `TestFS` failed on go1.17

### DIFF
--- a/fs.go
+++ b/fs.go
@@ -146,7 +146,9 @@ func (tfs *tarfs) ReadFile(name string) ([]byte, error) {
 		return nil, newErrDir("readfile", name)
 	}
 
-	return e.b, nil
+	buf := make([]byte, len(e.b))
+	copy(buf, e.b)
+	return buf, nil
 }
 
 var _ fs.StatFS = &tarfs{}


### PR DESCRIPTION
make copy in `ReadFile` since caller may modify returned bytes
Ref: https://github.com/golang/go/commit/35806efda21242df2c56ca276a842481acf6fea0