### PR TITLE
Fix incorrect header size assumption

### DIFF
--- a/copied_std.go
+++ b/copied_std.go
@@ -1,0 +1,371 @@
+// Copyright 2009 The Go Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package tarfs
+
+import (
+	"archive/tar"
+	"bytes"
+	"io"
+	"strconv"
+	"strings"
+)
+
+// start -- common.go
+
+const (
+	// Keywords for GNU sparse files in a PAX extended header.
+	paxGNUSparse          = "GNU.sparse."
+	paxGNUSparseNumBlocks = "GNU.sparse.numblocks"
+	paxGNUSparseOffset    = "GNU.sparse.offset"
+	paxGNUSparseNumBytes  = "GNU.sparse.numbytes"
+	paxGNUSparseMap       = "GNU.sparse.map"
+	paxGNUSparseName      = "GNU.sparse.name"
+	paxGNUSparseMajor     = "GNU.sparse.major"
+	paxGNUSparseMinor     = "GNU.sparse.minor"
+	paxGNUSparseSize      = "GNU.sparse.size"
+	paxGNUSparseRealSize  = "GNU.sparse.realsize"
+)
+
+type sparseEntry struct{ Offset, Length int64 }
+
+func (s sparseEntry) endOffset() int64 { return s.Offset + s.Length }
+
+// A sparse file can be represented as either a sparseDatas or a sparseHoles.
+// As long as the total size is known, they are equivalent and one can be
+// converted to the other form and back. The various tar formats with sparse
+// file support represent sparse files in the sparseDatas form. That is, they
+// specify the fragments in the file that has data, and treat everything else as
+// having zero bytes. As such, the encoding and decoding logic in this package
+// deals with sparseDatas.
+//
+// However, the external API uses sparseHoles instead of sparseDatas because the
+// zero value of sparseHoles logically represents a normal file (i.e., there are
+// no holes in it). On the other hand, the zero value of sparseDatas implies
+// that the file has no data in it, which is rather odd.
+//
+// As an example, if the underlying raw file contains the 10-byte data:
+//
+//	var compactFile = "abcdefgh"
+//
+// And the sparse map has the following entries:
+//
+//	var spd sparseDatas = []sparseEntry{
+//		{Offset: 2,  Length: 5},  // Data fragment for 2..6
+//		{Offset: 18, Length: 3},  // Data fragment for 18..20
+//	}
+//	var sph sparseHoles = []sparseEntry{
+//		{Offset: 0,  Length: 2},  // Hole fragment for 0..1
+//		{Offset: 7,  Length: 11}, // Hole fragment for 7..17
+//		{Offset: 21, Length: 4},  // Hole fragment for 21..24
+//	}
+//
+// Then the content of the resulting sparse file with a Header.Size of 25 is:
+//
+//	var sparseFile = "\x00"*2 + "abcde" + "\x00"*11 + "fgh" + "\x00"*4
+type (
+	sparseDatas []sparseEntry
+	sparseHoles []sparseEntry
+)
+
+func invertSparseEntries(src []sparseEntry, size int64) []sparseEntry {
+	dst := src[:0]
+	var pre sparseEntry
+	for _, cur := range src {
+		if cur.Length == 0 {
+			continue // Skip empty fragments
+		}
+		pre.Length = cur.Offset - pre.Offset
+		if pre.Length > 0 {
+			dst = append(dst, pre) // Only add non-empty fragments
+		}
+		pre.Offset = cur.endOffset()
+	}
+	pre.Length = size - pre.Offset // Possibly the only empty fragment
+	return append(dst, pre)
+}
+
+// end -- common.go
+
+// start -- format.go
+
+// Size constants from various tar specifications.
+const (
+	blockSize  = 512 // Size of each block in a tar stream
+	nameSize   = 100 // Max length of the name field in USTAR format
+	prefixSize = 155 // Max length of the prefix field in USTAR format
+)
+
+type block [blockSize]byte
+
+type headerV7 [blockSize]byte
+
+// Convert block to any number of formats.
+func (b *block) toV7() *headerV7   { return (*headerV7)(b) }
+func (b *block) toGNU() *headerGNU { return (*headerGNU)(b) }
+
+// func (b *block) toSTAR() *headerSTAR   { return (*headerSTAR)(b) }
+// func (b *block) toUSTAR() *headerUSTAR { return (*headerUSTAR)(b) }
+func (b *block) toSparse() sparseArray { return sparseArray(b[:]) }
+
+// func (h *headerV7) name() []byte     { return h[000:][:100] }
+// func (h *headerV7) mode() []byte     { return h[100:][:8] }
+// func (h *headerV7) uid() []byte      { return h[108:][:8] }
+// func (h *headerV7) gid() []byte      { return h[116:][:8] }
+func (h *headerV7) size() []byte { return h[124:][:12] }
+
+// func (h *headerV7) modTime() []byte  { return h[136:][:12] }
+// func (h *headerV7) chksum() []byte   { return h[148:][:8] }
+func (h *headerV7) typeFlag() []byte { return h[156:][:1] }
+
+// func (h *headerV7) linkName() []byte { return h[157:][:100] }
+
+type headerGNU [blockSize]byte
+
+// func (h *headerGNU) v7() *headerV7       { return (*headerV7)(h) }
+// func (h *headerGNU) magic() []byte       { return h[257:][:6] }
+// func (h *headerGNU) version() []byte     { return h[263:][:2] }
+// func (h *headerGNU) userName() []byte    { return h[265:][:32] }
+// func (h *headerGNU) groupName() []byte   { return h[297:][:32] }
+// func (h *headerGNU) devMajor() []byte    { return h[329:][:8] }
+// func (h *headerGNU) devMinor() []byte    { return h[337:][:8] }
+// func (h *headerGNU) accessTime() []byte  { return h[345:][:12] }
+// func (h *headerGNU) changeTime() []byte  { return h[357:][:12] }
+func (h *headerGNU) sparse() sparseArray { return sparseArray(h[386:][:24*4+1]) }
+
+// func (h *headerGNU) realSize() []byte    { return h[483:][:12] }
+
+// type headerSTAR [blockSize]byte
+
+// func (h *headerSTAR) v7() *headerV7      { return (*headerV7)(h) }
+// func (h *headerSTAR) magic() []byte      { return h[257:][:6] }
+// func (h *headerSTAR) version() []byte    { return h[263:][:2] }
+// func (h *headerSTAR) userName() []byte   { return h[265:][:32] }
+// func (h *headerSTAR) groupName() []byte  { return h[297:][:32] }
+// func (h *headerSTAR) devMajor() []byte   { return h[329:][:8] }
+// func (h *headerSTAR) devMinor() []byte   { return h[337:][:8] }
+// func (h *headerSTAR) prefix() []byte     { return h[345:][:131] }
+// func (h *headerSTAR) accessTime() []byte { return h[476:][:12] }
+// func (h *headerSTAR) changeTime() []byte { return h[488:][:12] }
+// func (h *headerSTAR) trailer() []byte    { return h[508:][:4] }
+
+// type headerUSTAR [blockSize]byte
+
+// func (h *headerUSTAR) v7() *headerV7     { return (*headerV7)(h) }
+// func (h *headerUSTAR) magic() []byte     { return h[257:][:6] }
+// func (h *headerUSTAR) version() []byte   { return h[263:][:2] }
+// func (h *headerUSTAR) userName() []byte  { return h[265:][:32] }
+// func (h *headerUSTAR) groupName() []byte { return h[297:][:32] }
+// func (h *headerUSTAR) devMajor() []byte  { return h[329:][:8] }
+// func (h *headerUSTAR) devMinor() []byte  { return h[337:][:8] }
+// func (h *headerUSTAR) prefix() []byte    { return h[345:][:155] }
+
+type sparseArray []byte
+
+func (s sparseArray) entry(i int) sparseElem { return sparseElem(s[i*24:]) }
+func (s sparseArray) isExtended() []byte     { return s[24*s.maxEntries():][:1] }
+func (s sparseArray) maxEntries() int        { return len(s) / 24 }
+
+type sparseElem []byte
+
+func (s sparseElem) offset() []byte { return s[0o0:][:12] }
+func (s sparseElem) length() []byte { return s[12:][:12] }
+
+// end -- format.go
+
+// start -- reader.go
+
+func mustReadFull(r io.Reader, b []byte) (int, error) {
+	n, err := tryReadFull(r, b)
+	if err == io.EOF {
+		err = io.ErrUnexpectedEOF
+	}
+	return n, err
+}
+
+func tryReadFull(r io.Reader, b []byte) (n int, err error) {
+	for len(b) > n && err == nil {
+		var nn int
+		nn, err = r.Read(b[n:])
+		n += nn
+	}
+	if len(b) == n && err == io.EOF {
+		err = nil
+	}
+	return n, err
+}
+
+func readGNUSparseMap1x0(r io.Reader) (sparseDatas, error) {
+	var (
+		cntNewline int64
+		buf        bytes.Buffer
+		blk        block
+	)
+
+	// feedTokens copies data in blocks from r into buf until there are
+	// at least cnt newlines in buf. It will not read more blocks than needed.
+	feedTokens := func(n int64) error {
+		for cntNewline < n {
+			if _, err := mustReadFull(r, blk[:]); err != nil {
+				return err
+			}
+			buf.Write(blk[:])
+			for _, c := range blk {
+				if c == '\n' {
+					cntNewline++
+				}
+			}
+		}
+		return nil
+	}
+
+	// nextToken gets the next token delimited by a newline. This assumes that
+	// at least one newline exists in the buffer.
+	nextToken := func() string {
+		cntNewline--
+		tok, _ := buf.ReadString('\n')
+		return strings.TrimRight(tok, "\n")
+	}
+
+	// Parse for the number of entries.
+	// Use integer overflow resistant math to check this.
+	if err := feedTokens(1); err != nil {
+		return nil, err
+	}
+	numEntries, err := strconv.ParseInt(nextToken(), 10, 0) // Intentionally parse as native int
+	if err != nil || numEntries < 0 || int(2*numEntries) < int(numEntries) {
+		return nil, tar.ErrHeader
+	}
+
+	// Parse for all member entries.
+	// numEntries is trusted after this since a potential attacker must have
+	// committed resources proportional to what this library used.
+	if err := feedTokens(2 * numEntries); err != nil {
+		return nil, err
+	}
+	spd := make(sparseDatas, 0, numEntries)
+	for i := int64(0); i < numEntries; i++ {
+		offset, err1 := strconv.ParseInt(nextToken(), 10, 64)
+		length, err2 := strconv.ParseInt(nextToken(), 10, 64)
+		if err1 != nil || err2 != nil {
+			return nil, tar.ErrHeader
+		}
+		spd = append(spd, sparseEntry{Offset: offset, Length: length})
+	}
+	return spd, nil
+}
+
+func readGNUSparseMap0x1(paxHdrs map[string]string) (sparseDatas, error) {
+	// Get number of entries.
+	// Use integer overflow resistant math to check this.
+	numEntriesStr := paxHdrs[paxGNUSparseNumBlocks]
+	numEntries, err := strconv.ParseInt(numEntriesStr, 10, 0) // Intentionally parse as native int
+	if err != nil || numEntries < 0 || int(2*numEntries) < int(numEntries) {
+		return nil, tar.ErrHeader
+	}
+
+	// There should be two numbers in sparseMap for each entry.
+	sparseMap := strings.Split(paxHdrs[paxGNUSparseMap], ",")
+	if len(sparseMap) == 1 && sparseMap[0] == "" {
+		sparseMap = sparseMap[:0]
+	}
+	if int64(len(sparseMap)) != 2*numEntries {
+		return nil, tar.ErrHeader
+	}
+
+	// Loop through the entries in the sparse map.
+	// numEntries is trusted now.
+	spd := make(sparseDatas, 0, numEntries)
+	for len(sparseMap) >= 2 {
+		offset, err1 := strconv.ParseInt(sparseMap[0], 10, 64)
+		length, err2 := strconv.ParseInt(sparseMap[1], 10, 64)
+		if err1 != nil || err2 != nil {
+			return nil, tar.ErrHeader
+		}
+		spd = append(spd, sparseEntry{Offset: offset, Length: length})
+		sparseMap = sparseMap[2:]
+	}
+	return spd, nil
+}
+
+// end -- reader.go
+
+// start -- strconv.go
+
+type parser struct {
+	err error // Last error seen
+}
+
+// parseString parses bytes as a NUL-terminated C-style string.
+// If a NUL byte is not found then the whole slice is returned as a string.
+func (*parser) parseString(b []byte) string {
+	if i := bytes.IndexByte(b, 0); i >= 0 {
+		return string(b[:i])
+	}
+	return string(b)
+}
+
+// parseNumeric parses the input as being encoded in either base-256 or octal.
+// This function may return negative numbers.
+// If parsing fails or an integer overflow occurs, err will be set.
+func (p *parser) parseNumeric(b []byte) int64 {
+	// Check for base-256 (binary) format first.
+	// If the first bit is set, then all following bits constitute a two's
+	// complement encoded number in big-endian byte order.
+	if len(b) > 0 && b[0]&0x80 != 0 {
+		// Handling negative numbers relies on the following identity:
+		//	-a-1 == ^a
+		//
+		// If the number is negative, we use an inversion mask to invert the
+		// data bytes and treat the value as an unsigned number.
+		var inv byte // 0x00 if positive or zero, 0xff if negative
+		if b[0]&0x40 != 0 {
+			inv = 0xff
+		}
+
+		var x uint64
+		for i, c := range b {
+			c ^= inv // Inverts c only if inv is 0xff, otherwise does nothing
+			if i == 0 {
+				c &= 0x7f // Ignore signal bit in first byte
+			}
+			if (x >> 56) > 0 {
+				p.err = tar.ErrHeader // Integer overflow
+				return 0
+			}
+			x = x<<8 | uint64(c)
+		}
+		if (x >> 63) > 0 {
+			p.err = tar.ErrHeader // Integer overflow
+			return 0
+		}
+		if inv == 0xff {
+			return ^int64(x)
+		}
+		return int64(x)
+	}
+
+	// Normal case is base-8 (octal) format.
+	return p.parseOctal(b)
+}
+
+func (p *parser) parseOctal(b []byte) int64 {
+	// Because unused fields are filled with NULs, we need
+	// to skip leading NULs. Fields may also be padded with
+	// spaces or NULs.
+	// So we remove leading and trailing NULs and spaces to
+	// be sure.
+	b = bytes.Trim(b, " \x00")
+
+	if len(b) == 0 {
+		return 0
+	}
+	x, perr := strconv.ParseUint(p.parseString(b), 8, 64)
+	if perr != nil {
+		p.err = tar.ErrHeader
+	}
+	return int64(x)
+}
+
+// end -- strconv.go

--- a/fs.go
+++ b/fs.go
@@ -9,10 +9,6 @@ import (
 	"strings"
 )
 
-const (
-	blockSize = 512 // Size of each block in a tar stream
-)
-
 type tarfs struct {
 	entries map[string]fs.DirEntry
 }
@@ -45,6 +41,10 @@ func New(r io.Reader) (fs.FS, error) {
 
 	tr := tar.NewReader(cr)
 
+	var (
+		bodyEnd, headerStart, headerEnd int64
+		blk                             block
+	)
 	for {
 		h, err := tr.Next()
 		if err == io.EOF {
@@ -53,22 +53,42 @@ func New(r io.Reader) (fs.FS, error) {
 		if err != nil {
 			return nil, err
 		}
-		if h.Typeflag == tar.TypeXGlobalHeader {
-			continue
-		}
 
-		name := path.Clean(h.Name)
-		if name == "." {
-			continue
+		headerEnd = cr.Count()
+
+		holes, _ := reconstructSparse(io.NewSectionReader(ra, headerStart, headerEnd-headerStart), h, &blk)
+
+		switch h.Typeflag {
+		case tar.TypeLink, tar.TypeSymlink, tar.TypeChar, tar.TypeBlock, tar.TypeDir, tar.TypeFifo,
+			tar.TypeCont, tar.TypeXHeader, tar.TypeXGlobalHeader,
+			tar.TypeGNULongName, tar.TypeGNULongLink:
+			// They have size for name.
+			bodyEnd = headerEnd
+		default:
+			// In testdata tars there's typeflag value not defined in archive/tar
+			// nor in https://www.gnu.org/software/tar/manual/html_node/Standard.html
+			bodyEnd = headerEnd + h.Size
+			if holes != nil {
+				// reverse-caluculating size
+				var holeSize int64
+				for _, hole := range holes {
+					holeSize += hole.Length
+				}
+				bodyEnd -= holeSize
+			}
 		}
 
 		de := fs.FileInfoToDirEntry(h.FileInfo())
-
-		if h.FileInfo().IsDir() {
-			tfs.append(name, newDirEntry(de))
-		} else {
-			tfs.append(name, &regEntry{de, name, ra, cr.Count() - blockSize})
+		name := path.Clean(h.Name)
+		if h.Typeflag != tar.TypeXGlobalHeader && name != "." {
+			if h.FileInfo().IsDir() {
+				tfs.append(name, newDirEntry(de))
+			} else {
+				tfs.append(name, &regEntry{de, name, ra, headerStart})
+			}
 		}
+
+		headerStart = bodyEnd + ((-bodyEnd) & (blockSize - 1))
 	}
 
 	return tfs, nil

--- a/fs_std_test.go
+++ b/fs_std_test.go
@@ -1,0 +1,138 @@
+package tarfs
+
+import (
+	"archive/tar"
+	"context"
+	"errors"
+	"fmt"
+	"io"
+	"io/fs"
+	"os"
+	"os/exec"
+	"path"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func stdTarTestFiles(ctx context.Context) ([]string, error) {
+	testdataDir, err := stdTarTestDir(ctx)
+	if err != nil {
+		return nil, err
+	}
+	dirents, err := os.ReadDir(testdataDir)
+	if err != nil {
+		return nil, err
+	}
+	names := make([]string, 0, len(dirents))
+	for _, dirent := range dirents {
+		if !dirent.Type().IsRegular() || !strings.HasSuffix(dirent.Name(), ".tar") {
+			continue
+		}
+		names = append(names, filepath.Join(testdataDir, dirent.Name()))
+	}
+	return names, nil
+}
+
+func stdTarTestDir(ctx context.Context) (string, error) {
+	gorootBytes, err := exec.CommandContext(ctx, "go", "env", "GOROOT").Output()
+	if err != nil {
+		var cmdErr *exec.ExitError
+		if errors.As(err, &cmdErr) {
+			return "", fmt.Errorf("%w: %s", err, string(cmdErr.Stderr))
+		}
+		return "", err
+	}
+	goroot := strings.TrimSpace(string(gorootBytes))
+	return filepath.Join(goroot, "src", "archive", "tar", "testdata"), nil
+}
+
+func collectTarContents(tarPath string) (map[string][]byte, error) {
+	f, err := os.Open(tarPath)
+	if err != nil {
+		return nil, err
+	}
+	collected := make(map[string][]byte)
+	tr := tar.NewReader(f)
+	for {
+		h, err := tr.Next()
+		if err != nil {
+			if err == io.EOF {
+				break
+			}
+			return collected, err
+		}
+		if h.Typeflag == tar.TypeReg || h.Typeflag == tar.TypeRegA {
+			bin, err := io.ReadAll(tr)
+			if err != nil {
+				return collected, err
+			}
+			collected[path.Clean(h.Name)] = bin
+		}
+	}
+	return collected, nil
+}
+
+func colllectTarFs(fsys fs.FS) (map[string][]byte, error) {
+	collected := make(map[string][]byte)
+	err := fs.WalkDir(fsys, ".", func(path string, d fs.DirEntry, err error) error {
+		if path == "." || d.IsDir() || err != nil {
+			return err
+		}
+		info, err := d.Info()
+		if err != nil {
+			return err
+		}
+		if !info.Mode().IsRegular() {
+			return nil
+		}
+		bin, err := fs.ReadFile(fsys, path)
+		if err != nil {
+			return err
+		}
+		collected[path] = bin
+		return nil
+	})
+	return collected, err
+}
+
+func TestFs_testdata_from_stdlib(t *testing.T) {
+	assert := assert.New(t)
+	require := require.New(t)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	t.Cleanup(cancel)
+	testdataFilenames, err := stdTarTestFiles(ctx)
+
+	require.NoError(err, "when reading $(go env GOROOT)/src/archive/tar/testdata")
+
+	for _, testFilename := range testdataFilenames {
+		baseName := filepath.Base(testFilename)
+		if baseName == "gnu-sparse-big.tar" || baseName == "pax-sparse-big.tar" || baseName == "gnu-not-utf8.tar" {
+			// big files take too long time to complete.
+			// paths in not-utf8 can't pass fs.ValidPath test.
+			continue
+		}
+		fromArchiveTar, err := collectTarContents(testFilename)
+		if err != nil {
+			// something that archive/tar can't handle
+			continue
+		}
+		t.Run(baseName, func(t *testing.T) {
+			f, err := os.Open(testFilename)
+			require.NoError(err, "when opening %q", testFilename)
+			defer f.Close()
+			fsys, err := New(f)
+			require.NoError(err, "when New(%q)", testFilename)
+			fromTarFs, err := colllectTarFs(fsys)
+			require.NoError(err, "reading %q with *Fs", testFilename)
+			for name := range fromArchiveTar {
+				// basically archive/tar is assumed correct.
+				assert.Equal(fromArchiveTar[name], fromTarFs[name])
+			}
+		})
+	}
+}

--- a/reconstruct_sparse.go
+++ b/reconstruct_sparse.go
@@ -1,0 +1,104 @@
+package tarfs
+
+import (
+	"archive/tar"
+	"io"
+)
+
+func reconstructSparse(sr *io.SectionReader, hdr *tar.Header, blk *block) (sparseHoles, error) {
+	if hdr.Typeflag == tar.TypeXGlobalHeader {
+		return nil, nil
+	}
+
+	var p parser
+	for {
+		n, err := io.ReadFull(sr, blk[:])
+		if (err != nil && err != io.EOF) || n == 0 {
+			return nil, err
+		}
+		switch flag := blk.toV7().typeFlag()[0]; flag {
+		case tar.TypeXHeader, tar.TypeXGlobalHeader:
+			size := p.parseNumeric(blk.toV7().size())
+			size += (-size) & (blockSize - 1)
+			_, _ = sr.Seek(size, io.SeekCurrent)
+			continue
+		case tar.TypeGNULongName, tar.TypeGNULongLink:
+			size := p.parseNumeric(blk.toV7().size())
+			size += (-size) & (blockSize - 1)
+			_, _ = sr.Seek(size, io.SeekCurrent)
+			continue
+		default:
+			return handleSparseFile(sr, hdr, blk)
+		}
+	}
+}
+
+func handleSparseFile(sr io.Reader, hdr *tar.Header, rawHdr *block) (sparseHoles, error) {
+	var spd sparseDatas
+	var err error
+	if hdr.Typeflag == tar.TypeGNUSparse {
+		spd, err = readOldGNUSparseMap(sr, rawHdr)
+	} else {
+		spd, err = readGNUSparsePAXHeaders(sr, hdr)
+	}
+
+	if err == nil && spd != nil {
+		return invertSparseEntries(spd, hdr.Size), nil
+	}
+
+	return nil, err
+}
+
+func readOldGNUSparseMap(sr io.Reader, blk *block) (sparseDatas, error) {
+	var p parser
+	s := blk.toGNU().sparse()
+	spd := make(sparseDatas, 0, s.maxEntries())
+	for {
+		for i := 0; i < s.maxEntries(); i++ {
+			// This termination condition is identical to GNU and BSD tar.
+			if s.entry(i).offset()[0] == 0x00 {
+				break // Don't return, need to process extended headers (even if empty)
+			}
+			offset := p.parseNumeric(s.entry(i).offset())
+			length := p.parseNumeric(s.entry(i).length())
+			if p.err != nil {
+				return nil, p.err
+			}
+			spd = append(spd, sparseEntry{Offset: offset, Length: length})
+		}
+
+		if s.isExtended()[0] > 0 {
+			// There are more entries. Read an extension header and parse its entries.
+			if _, err := mustReadFull(sr, blk[:]); err != nil {
+				return nil, err
+			}
+			s = blk.toSparse()
+			continue
+		}
+		return spd, nil // Done
+	}
+}
+
+func readGNUSparsePAXHeaders(sr io.Reader, hdr *tar.Header) (sparseDatas, error) {
+	// Identify the version of GNU headers.
+	var is1x0 bool
+	major, minor := hdr.PAXRecords[paxGNUSparseMajor], hdr.PAXRecords[paxGNUSparseMinor]
+	switch {
+	case major == "0" && (minor == "0" || minor == "1"):
+		is1x0 = false
+	case major == "1" && minor == "0":
+		is1x0 = true
+	case major != "" || minor != "":
+		return nil, nil // Unknown GNU sparse PAX version
+	case hdr.PAXRecords[paxGNUSparseMap] != "":
+		is1x0 = false // 0.0 and 0.1 did not have explicit version records, so guess
+	default:
+		return nil, nil // Not a PAX format GNU sparse file.
+	}
+
+	// Read the sparse map according to the appropriate format.
+	if is1x0 {
+		return readGNUSparseMap1x0(sr)
+	}
+	return readGNUSparseMap0x1(hdr.PAXRecords)
+}


### PR DESCRIPTION
Closes #21 

I propose fix for the issue but I'm not sure this should be merged, since it needs copying Go's std library and reconstruction of sparse infomation.
This adds complexity to codebase but I believe the part I've copied from std is stable enough to maintain.

The current implementation [assumes headers are always only single block long](https://github.com/nlepage/go-tarfs/blob/v1.2.1/fs.go#L70).

But as per spec and `archive/tar` implementation, some kind of headers may span multiple blocks.

- PAXHeader Records
- GNULongName
- Sparse headers: see [GNU Tar Manual: Storing Sparse Files](https://www.gnu.org/software/tar/manual/html_node/Sparse-Formats.html#Sparse-Formats)

All of them may span multiple blocks or modification header which only relevant to a next tar entry.

I think we have roughly 3 options:
- 1. ultimately go different way. Implement our own tar parser
- 2. Read entire `*tar.Reader` after each time `*tar.Reader.Next` is called, and collect offset of start and end of header.
- 3. Skip reading `*tar.Reader`, only collect header end offsets but reconstruct sparse infomation. And then calculate actual body length by subtracting sparse hole sizes from body size.

`1.` and `2.` are not option because they are too large to have or too slow for large tar archives.

I took `3.`. This needs copying of Go std library.

I've first added tests where it reads some tar archives from `$(go env GOROOT)/src/archive/tar/testdata` using both `archive/tar` and `*go-tarfs.Fs`, then compare bytes read.

There was only one, but apparantly failing case.

```
$ /go/pkg/mod/golang.org/toolchain@v0.0.1-go1.17.linux-amd64/bin/go test ./...
--- FAIL: TestFs_testdata_from_stdlib (0.22s)
    fs_std_test.go:131: 
                Error Trace:    fs_std_test.go:131
                Error:          Received unexpected error:
                                archive/tar: invalid tar header
                Test:           TestFs_testdata_from_stdlib
                Messages:       reading "/home/watage/.local/go/src/archive/tar/testdata/pax-nil-sparse-data.tar" with *Fs
    --- FAIL: TestFs_testdata_from_stdlib/pax-nil-sparse-data.tar (0.00s)
        testing.go:1169: test executed panic(nil) or runtime.Goexit: subtest may have called FailNow on a parent test
FAIL
FAIL    github.com/nlepage/go-tarfs     0.263s
ok      github.com/nlepage/go-tarfs/benchmarks  (cached) [no tests to run]
FAIL
```

After fix, it passes.

```
$ /go/pkg/mod/golang.org/toolchain@v0.0.1-go1.17.linux-amd64/bin/go test ./...
ok      github.com/nlepage/go-tarfs     0.282s
ok      github.com/nlepage/go-tarfs/benchmarks  1.849s [no tests to run]
```

What I did is basically same thing I've done in [my own tarfs implementation](https://github.com/ngicks/go-fsys-helper/blob/ea9bac0ae98290572083ac450862805f9a7ebe52/tarfs/headers.go) with slight simplification.